### PR TITLE
Use BufReader::get_mut to write to a socket

### DIFF
--- a/src/tcp_client.rs
+++ b/src/tcp_client.rs
@@ -51,7 +51,7 @@ impl Client for TcpClient {
         let s = &mut me.sock;
 
         // encode the request
-        s.get_ref().write_all(&(req.finish(id)))?;
+        s.get_mut().write_all(&(req.finish(id)))?;
 
         // read the response
         loop {


### PR DESCRIPTION
On rustc 1.37.0-nightly (5f9c0448d 2019-06-25) fails with
```
    error[E0596]: cannot borrow data in a `&` reference as mutable
      --> /root/.cargo/git/checkouts/conetty-a662beb3b89f3dc0/7acf957/src/tcp_client.rs:54:9
       |
    54 |         s.get_ref().write_all(&(req.finish(id)))?;
       |         ^^^^^^^^^^^ cannot borrow as mutable
    
    error: aborting due to previous error
```